### PR TITLE
Fix fluid_down and fluid_up helper functions

### DIFF
--- a/lib/yi-tools.lua
+++ b/lib/yi-tools.lua
@@ -75,12 +75,20 @@ end
 
 -- Used to make icons for Fluid -> Unicomp recipes
 function yi.lib.recipe.atomics.fluid_down(icon_name, size)
-	local item_name = data.raw.fluid[icon_name].icon
-	local image_size = size or 64
+	local fluid = data.raw.fluid[icon_name]
+	local fluid_name
+	local image_size
+	if fluid.icons then
+		fluid_name = fluid.icons[1].icon
+		image_size = fluid.icons[1].icon_size or size or 64
+	else
+		fluid_name = fluid.icon
+		image_size = fluid.icon_size or size or 64
+	end
 	if type(icon_name) == "string" then
 		return {
 			{
-				icon = item_name,
+				icon = fluid_name,
 				icon_size = image_size,
 			},
 			{
@@ -94,12 +102,20 @@ end
 
 -- Used to make icons for Unicomp -> Fluid recipes
 function yi.lib.recipe.atomics.fluid_up(icon_name, size)
-	local item_name = data.raw.fluid[icon_name].icon
-	local image_size = size or 64
+	local fluid = data.raw.fluid[icon_name]
+	local fluid_name
+	local image_size
+	if fluid.icons then
+		fluid_name = fluid.icons[1].icon
+		image_size = fluid.icons[1].icon_size or size or 64
+	else
+		fluid_name = fluid.icon
+		image_size = fluid.icon_size or size or 64
+	end
 	if type(icon_name) == "string" then
 		return {
 			{
-				icon = item_name,
+				icon = fluid_name,
 				icon_size = image_size,
 			},
 			{


### PR DESCRIPTION
Functions fluid_down and fluid_up try to treat fluid icons in only the legacy way when getting their icon path. This results in a nil value, causing the first icon in the IconData array to have a nil icon.

This causes errors in the Yuoki Tech Tree Extra Vanilla mod, which is relying on the fluid_up function for their technology icons (https://github.com/MnHebi/Yuoki-Tech-Tree-Extra-Vanilla/blob/main/prototypes/technology/yi_core.lua#L2590C4-L2590C56): `Failed to load mods: Error while loading technology prototype "yi-oil-atomics" (technology): Key "icon" not found in property tree at ROOT.technology.yi-oil-atomics.icons[0]`

The fix here is to check if the fluid being requested for in the helper method is either a modern fluid or a legacy fluid first, then pull the icon information from it in their respective way.